### PR TITLE
Python3 compatibility, better progress bars, code cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+test
+test.*
+*.pyc

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,0 @@
-# Todo List
-* Clean up code a bit, standardize shit, work out kinks
-* Write the transfer-enc.py client  
-* Done?  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-clint
+progressbar2

--- a/transfer.py
+++ b/transfer.py
@@ -1,12 +1,34 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # coding: utf-8
 # transfer.sh cleartext client
-# Version: 20150413.1
-# Author: Darren Martyn
-import requests
-from clint.textui import progress
+# Version: 20161214.1
+# Author: Darren Martyn, Harry Roberts
+from __future__ import print_function
 import sys
 import os
+import logging
+import argparse
+import requests
+import progressbar
+
+
+LOG = logging.getLogger(__name__)
+
+
+def make_progress_bar():
+    return progressbar.ProgressBar(
+        redirect_stdout=True,
+        redirect_stderr=True,
+        widgets=[
+            progressbar.Percentage(),
+            progressbar.Bar(),
+            ' (',
+            progressbar.AdaptiveTransferSpeed(),
+            ' ',
+            progressbar.ETA(),
+            ') ',
+        ])
+
 
 class upload_in_chunks(object):
     def __init__(self, filename, chunksize=1 << 13):
@@ -14,21 +36,23 @@ class upload_in_chunks(object):
         self.chunksize = chunksize
         self.totalsize = os.path.getsize(filename)
         self.readsofar = 0
+        self.bar = make_progress_bar()
 
     def __iter__(self):
         with open(self.filename, 'rb') as file:
+            self.bar.start(self.totalsize)
             while True:
                 data = file.read(self.chunksize)
                 if not data:
-                    sys.stderr.write("\n")
                     break
                 self.readsofar += len(data)
-                percent = self.readsofar * 1e2 / self.totalsize
-                sys.stderr.write("\r{percent:3.0f}%".format(percent=percent))
+                self.bar.update(self.readsofar)
                 yield data
+            self.bar.finish()
 
     def __len__(self):
         return self.totalsize
+
 
 class IterableToFileAdapter(object):
     def __init__(self, iterable):
@@ -41,58 +65,80 @@ class IterableToFileAdapter(object):
     def __len__(self):
         return self.length
 
+
 def upload(file_path):
-    # thanks to http://stackoverflow.com/questions/13909900/progress-of-python-requests-post/13911048#13911048
     try:
         filepath, filename = os.path.split(file_path)
-    except Exception, e:
-        print "{-} Something has gone horribly wrong! Please report on the github issue tracker with the following backtrace: \n%s" %(e)
+    except Exception:
+        LOG.exception("Invalid file path")
+        return
     upload_url = "https://transfer.sh/%s" %(filename)
     try:
         it = upload_in_chunks(file_path, 10)
         r = requests.put(url=upload_url, data=IterableToFileAdapter(it))
-    except Exception, e:
-        print "{-} Something has gone horribly wrong! Please report on the github issue tracker with the following backtrace: \n%s" %(e)
+    except Exception:
+        LOG.exception("Failed to upload file")
+        return
     try:
         return r.text.strip()
-    except Exception, e:
-        print "{-} Something has gone horribly wrong! Please report on the github issue tracker with the following backtrace: \n%s" %(e)
+    except Exception:
+        LOG.exception("Failed to get uploaded URL")
+
 
 def download(url):
     # kludge for now
     filename = url.replace("https://transfer.sh", "")
     filename = filename.split("/")[2]
-    print "{*} Saving file to %s" %(filename)
-    try:
-        r = requests.get(url=url, stream=True)
-        with open(filename, 'wb') as f:
-            total_length = int(r.headers.get('content-length'))
-            for chunk in progress.bar(r.iter_content(chunk_size=1024), expected_size=(total_length/1024) + 1):
-                if chunk:
-                    f.write(chunk)
-                    f.flush()
-    except Exception, e:
-        print "{-} Something has gone horribly wrong! Please report on the github issue tracker with the following backtrace: \n%s" %(e)
+    LOG.info("Saving %r to %r", url, filename)
+    r = requests.get(url=url, stream=True)
+    with open(filename, 'wb') as f:
+        total_length = int(r.headers.get('content-length'))
+        bar = make_progress_bar()
+        bar.start(total_length)
+        readsofar = 0
+        for chunk in r.iter_content(chunk_size=1024):
+            if chunk:
+                readsofar += len(chunk)
+                bar.update(readsofar)
+                f.write(chunk)
+                f.flush()
 
-def main(args):
-    if len(args) != 2:
-       sys.exit("use: %s <path/to/file> OR <transfer.sh url>" %(args[0]))
-    if "https://transfer.sh" in args[1]:
-        print "{+} Downloading %s" %(args[1])
-        try:
-            download(url=args[1])
-        except Exception, e:
-            print "{-} Something has gone horribly wrong! Please report on the github issue tracker with the following backtrace: \n%s" %(e)
-    else:
-        try:
-            print "{+} Uploading %s" %(args[1])
-            file_url = upload(file_path=args[1]) 
-        except Exception, e:
-            print "{-} Something has gone horribly wrong! Please report on the github issue tracker with the following backtrace: \n%s" %(e)
-        if file_url != None:
-            print file_url
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='http://transfer.sh utility')
+    parser.add_argument('files', nargs='*', help='Files to upload')
+    args = parser.parse_args()
+    if not args.files:
+        parser.print_help()
+        sys.exit(1)
+    return args
+
+
+def main():
+    args = parse_args()
+    for file_or_url in args.files:
+        if "https://transfer.sh" in file_or_url:
+            try:
+                download(url=file_or_url)
+            except Exception:
+                LOG.exception("error while downloading %s", file_or_url)
+                return 2
         else:
-            sys.exit("Something fucked up... Like, seriously. Possibly an issue at the remote end?")
+            if not os.path.exists(file_or_url):
+                LOG.warning("File doesn't exist: %r", file_or_url)
+                continue
+            try:
+                file_url = upload(file_path=file_or_url) 
+            except Exception:
+                LOG.exception("error while uploading %s", file_or_url)
+                return 3
+            if not file_url:
+                LOG.error("Could not get uploaded file url!")
+                return 4
+            print("\n"+file_url+"\n")
+    return 0
         
+
 if __name__ == "__main__":
-    main(args=sys.argv)
+    logging.basicConfig()
+    sys.exit(main())


### PR DESCRIPTION
Converted progress bars from `clint.progressbar` to `progressbar2`, now has bars for both upload & download.

Made compatible with Python 2 and 3, will use whatever the system Python is in shebang line.

General code cleanups, use `logging` instead of `print` etc.

Also allowed for an arbitrary number of files to be uploaded at once.

Added `argparse` support, can now pass `-c` to encrypt the uploaded files with a random password.

It outputs the password as a `#XXXX` anchor.

Would be good to make the progressbar disappear after uploads so it doesn't shit-up the results.